### PR TITLE
fix error handling in node-sso-example

### DIFF
--- a/node-admin-portal-example/index.js
+++ b/node-admin-portal-example/index.js
@@ -16,5 +16,5 @@ app.use(morgan('dev'))
 app.use('/', router)
 
 app.listen(port, () => {
-    console.log(`⚡️ [server]: Server is running at https://localhost:${port}`)
+    console.log(`⚡️ [server]: Server is running at http://localhost:${port}`)
 })

--- a/node-audit-logs-example/index.js
+++ b/node-audit-logs-example/index.js
@@ -18,5 +18,5 @@ app.use(morgan('dev'))
 app.use('/', router)
 
 app.listen(port, () => {
-    console.log(`⚡️ [server]: Server is running at https://localhost:${port}`)
+    console.log(`⚡️ [server]: Server is running at http://localhost:${port}`)
 })

--- a/node-directory-sync-example/index.js
+++ b/node-directory-sync-example/index.js
@@ -14,7 +14,7 @@ const port = process.env.PORT || '8000'
 const workos = new WorkOS(process.env.WORKOS_API_KEY)
 
 const server = app.listen(port, () => {
-    console.log(`⚡️ [server]: Server is running at https://localhost:${port}`)
+    console.log(`⚡️ [server]: Server is running at http://localhost:${port}`)
 })
 
 const io = new Server(server)

--- a/node-magic-link-example/index.js
+++ b/node-magic-link-example/index.js
@@ -16,5 +16,5 @@ app.use(morgan('dev'))
 app.use('/', router)
 
 app.listen(port, () => {
-    console.log(`⚡️ [server]: Server is running at https://localhost:${port}`)
+    console.log(`⚡️ [server]: Server is running at http://localhost:${port}`)
 })

--- a/node-mfa-example/index.js
+++ b/node-mfa-example/index.js
@@ -18,5 +18,5 @@ app.use(morgan('dev'))
 app.use('/', router)
 
 app.listen(port, () => {
-    console.log(`⚡️ [server]: Server is running at https://localhost:${port}`)
+    console.log(`⚡️ [server]: Server is running at http://localhost:${port}`)
 })

--- a/node-sso-example/index.js
+++ b/node-sso-example/index.js
@@ -18,5 +18,5 @@ app.use(morgan('dev'))
 app.use('/', router)
 
 app.listen(port, () => {
-    console.log(`⚡️ [server]: Server is running at https://localhost:${port}`)
+    console.log(`⚡️ [server]: Server is running at http://localhost:${port}`)
 })

--- a/node-sso-example/routes/index.js
+++ b/node-sso-example/routes/index.js
@@ -16,7 +16,7 @@ app.use(
 
 const workos = new WorkOS(process.env.WORKOS_API_KEY)
 const clientID = process.env.WORKOS_CLIENT_ID
-const organizationID = ''
+const organizationID = 'org_test_idp'
 const redirectURI = 'http://localhost:8000/callback'
 const state = ''
 
@@ -56,22 +56,31 @@ router.post('/login', (req, res) => {
 })
 
 router.get('/callback', async (req, res) => {
+    let errorMessage
     try {
-        const { code } = req.query
+        const { code, error } = req.query
 
-        const profile = await workos.sso.getProfileAndToken({
-            code,
-            clientID,
-        })
-        const json_profile = JSON.stringify(profile, null, 4)
+        if (error) {
+            errorMessage = `Redirect callback error: ${error}`
+        } else {
+            const profile = await workos.sso.getProfileAndToken({
+                code,
+                clientID,
+            })
+            const json_profile = JSON.stringify(profile, null, 4)
 
-        session.first_name = profile.profile.first_name
-        session.profile = json_profile
-        session.isloggedin = true
-
-        res.redirect('/')
+            session.first_name = profile.profile.first_name
+            session.profile = json_profile
+            session.isloggedin = true
+        }
     } catch (error) {
-        res.render('error.ejs', { error: error })
+        errorMessage = `Code for profile exchange error: ${error}`
+    }
+
+    if (errorMessage) {
+        res.render('error.ejs', { error: errorMessage })
+    } else {
+        res.redirect('/')
     }
 })
 


### PR DESCRIPTION
Includes the following updates:

- Improve `node-sso-example` app callback route to distinguish between errors provided in the redirect and those from exchanging the code for a profile and token.
- Update the `Server is running...` messages of all apps to correctly state `http` and not `https`
- update the `node-sso-example` app to use the `organizationId=org_test_idp` by default